### PR TITLE
Add macOS Muse S Athena analysis pipeline on top of OpenMuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,10 @@ __pycache__/
 *.pyc
 
 BlueMuse/AppPackages/
+
+# macOS Athena pipeline — generated / data files (kept out of git)
+.DS_Store
+*.egg-info/
+out/
+runs/
+athena_test.txt

--- a/analyze_athena_test.py
+++ b/analyze_athena_test.py
@@ -1,0 +1,33 @@
+"""Decode athena_test.txt (raw BLE notifications) into DataFrames and summarize."""
+from pathlib import Path
+import numpy as np
+from OpenMuse.decode import decode_rawdata
+
+INFILE = Path(__file__).parent / "athena_test.txt"
+
+with open(INFILE) as f:
+    messages = f.read().splitlines()
+print(f"Loaded {len(messages)} raw notification lines from {INFILE.name}\n")
+
+data = decode_rawdata(messages)
+
+for name, df in data.items():
+    if df.empty:
+        print(f"{name}: empty")
+        continue
+    n = len(df)
+    t = df["time"].to_numpy()
+    duration = t[-1] - t[0]
+    rate = (n - 1) / duration if duration > 0 else float("nan")
+    chan_cols = [c for c in df.columns if c != "time"]
+    print(f"{name}: {n} samples over {duration:.2f}s  →  ~{rate:.1f} Hz")
+    print(f"  channels: {chan_cols}")
+    if name in ("EEG", "OPTICS", "ACCGYRO"):
+        arr = df[chan_cols].to_numpy()
+        print(f"  per-channel mean : {np.array2string(arr.mean(axis=0), precision=2)}")
+        print(f"  per-channel std  : {np.array2string(arr.std(axis=0),  precision=2)}")
+        print(f"  per-channel min  : {np.array2string(arr.min(axis=0),  precision=2)}")
+        print(f"  per-channel max  : {np.array2string(arr.max(axis=0),  precision=2)}")
+    elif name == "BATTERY":
+        print(f"  battery_percent: {df['battery_percent'].iloc[0]:.2f} → {df['battery_percent'].iloc[-1]:.2f}")
+    print()

--- a/contributions/openmuse_pr/ISSUE.md
+++ b/contributions/openmuse_pr/ISSUE.md
@@ -1,0 +1,82 @@
+# Proposal: add `preprocess_eeg`, `eeg_band_power`, `hrv_from_bvp` to `process.py`
+
+Hi — first, thank you for OpenMuse. It's the only working path to LSL/Python
+streaming from the Muse S Athena that I'm aware of, and decoding into clean
+labelled DataFrames is great.
+
+While building a research pipeline on top of it I noticed three small gaps
+I'd be happy to fill via PR if you're open to it. I wanted to scope-check
+first so I don't waste a review cycle.
+
+## Gaps
+
+`process.py` currently has `preprocess_accgyro`, `preprocess_ppg`, and
+`preprocess_fnirs` but no `preprocess_eeg`. And while `preprocess_ppg`
+produces a clean fused BVP, there's no step to turn it into the standard
+HRV indices (SDNN / RMSSD / pNN50 / LF–HF) that most cardiovascular
+analyses use.
+
+## Proposal
+
+Three functions, all reusing `apply_butter_filter` and `decode.EEG_CHANNELS`,
+no new dependencies beyond `scipy.signal` (already used):
+
+| Function | Returns | Notes |
+| --- | --- | --- |
+| `preprocess_eeg(df, sampling_rate=256, hp_cutoff=1.0, lp_cutoff=40.0, notch_freq=60.0, notch_q=30.0, main_only=True)` | `pd.DataFrame` | Zero-phase bandpass + optional powerline notch. Mirrors the `preprocess_accgyro` signature/idiom. The bandpass also removes the standing ~700 µV DC bias from the Athena's ADC. |
+| `eeg_band_power(df, sampling_rate=256, bands=None, win_sec=2.0, step_sec=1.0)` | long-form `pd.DataFrame` | Windowed band power via Welch + frequency integration. Default bands are the standard δ θ α β γ split. Returns `[time, channel, band, power_uV2]` for easy `groupby` analyses. |
+| `hrv_from_bvp(bvp, sampling_rate=64, min_hr_bpm=30, max_hr_bpm=200)` | `(summary_df, ibis_df)` | Detects systolic peaks on the BVP produced by `preprocess_ppg` (whose polarity flip is already accounted for), drops physiologically implausible IBIs, and returns time-domain (SDNN/RMSSD/pNN50/mean HR) + frequency-domain (VLF/LF/HF, LF–HF ratio, normalised units) per the Task Force 1996 conventions. Frequency-domain returned as NaN when there is <30 s of beats, by design. |
+
+A reference implementation matching your style is at the bottom of this
+issue. It's been validated against a real Athena recording (firmware 3.1.23,
+preset p1041, EEG 256 Hz / OPTICS 64 Hz) and the three functions chain
+together as `decode → preprocess_eeg → eeg_band_power` and
+`decode → preprocess_ppg → hrv_from_bvp`.
+
+## Scope (deliberately staying out of fNIRS)
+
+I saw #23 and your comment that the optics → fNIRS computation is still
+unclear/unvalidated, plus a recent firmware update changed optics behavior.
+The three functions here intentionally don't go near that area — two are
+EEG signal processing (bandpass / notch / Welch band power, no Athena-specific
+assumptions beyond the channel names) and the third works on the BVP that
+`preprocess_ppg` already returns, which is a signal-processing-only product.
+So the PR adds capability in the well-understood parts of the chain without
+expanding the surface where firmware changes or assumption drift would hurt.
+
+## Open questions before I send a PR
+
+1. **Scope**: are you happy with all three landing in one PR, or would you
+   prefer them split (e.g. EEG functions first, HRV as a follow-up)?
+2. **Naming**: I followed your `preprocess_*` convention for EEG; for the
+   HRV side I went with `hrv_from_bvp` so the dependency on `preprocess_ppg`
+   is explicit. Happy to rename either to match a different preference.
+3. **EU mains**: I defaulted `notch_freq=60.0`. Happy to change to `None`,
+   or accept a list, or follow a different convention you prefer.
+4. **AUX channels in `preprocess_eeg`**: I default to dropping them
+   (`main_only=True`). Toggleable, but I'd like a sanity check that
+   matches your view of how the AUX channels are typically used.
+5. **Tests**: do you have a preferred test-data convention I should follow,
+   or should the PR ship without tests (consistent with the current code)?
+
+If the answer to (1)/(2)/(3)/(4) is "looks fine", I'll send a PR matching
+your style with the three functions plus minimal docstring tweaks. If you'd
+rather not have them upstream, I'll spin them out into a sister package
+that depends on OpenMuse and move on.
+
+Thanks again for the project.
+
+---
+
+### Reference implementation
+
+<details>
+<summary>process.py additions (drop-in to the existing module)</summary>
+
+```python
+# (Paste contents of contributions/openmuse_pr/process_eeg_hrv.py here in the
+# actual issue, or upload as a gist and link to it. The two `# =================`
+# section headers match the file's current style.)
+```
+
+</details>

--- a/contributions/openmuse_pr/process_eeg_hrv.py
+++ b/contributions/openmuse_pr/process_eeg_hrv.py
@@ -1,0 +1,299 @@
+"""
+Proposed additions to OpenMuse/process.py — three small, focused functions
+that fill clear gaps in the current preprocessing/feature surface:
+
+    1) preprocess_eeg(df, ...)        Bandpass + notch + main-channel selection.
+                                      Matches the preprocess_accgyro/ppg/fnirs pattern.
+
+    2) eeg_band_power(df, sr, ...)    Windowed PSD-based band power (δ θ α β γ).
+                                      Returns a long-form DataFrame suitable for groupby.
+
+    3) hrv_from_bvp(bvp, sr)          Time + frequency domain HRV from the BVP
+                                      signal that preprocess_ppg already produces.
+
+These reuse the existing `apply_butter_filter` and the channel constants from
+OpenMuse/decode.py. No new dependencies. All functions are tested against
+real Muse S Athena recordings.
+
+To apply: paste each function into `OpenMuse/process.py` after the matching
+section (EEG section can be inserted between PPG and fNIRS; HRV section
+naturally goes after PPG since hrv_from_bvp consumes preprocess_ppg's output).
+"""
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+from scipy import signal
+
+# These come from OpenMuse/process.py and OpenMuse/decode.py respectively.
+# Stub-imported here so the file can be smoke-tested standalone.
+try:
+    from OpenMuse.process import apply_butter_filter
+    from OpenMuse.decode import EEG_CHANNELS
+except ImportError:  # pragma: no cover - upstream provides these
+    EEG_CHANNELS = (
+        "EEG_TP9", "EEG_AF7", "EEG_AF8", "EEG_TP10",
+        "AUX_1", "AUX_2", "AUX_3", "AUX_4",
+    )
+
+    def apply_butter_filter(data, cutoff, sampling_rate, btype="low", order=4):
+        nyq = 0.5 * sampling_rate
+        if btype == "band":
+            wn = [c / nyq for c in cutoff]
+        else:
+            wn = cutoff / nyq
+        sos = signal.butter(order, wn, btype=btype, output="sos")
+        data = np.asarray(data)
+        if data.ndim == 1:
+            return signal.sosfiltfilt(sos, data)
+        return np.vstack([signal.sosfiltfilt(sos, d) for d in data])
+
+
+EEG_MAIN_CHANNELS = ("EEG_TP9", "EEG_AF7", "EEG_AF8", "EEG_TP10")
+
+EEG_BANDS_DEFAULT = {
+    "delta": (1.0, 4.0),
+    "theta": (4.0, 8.0),
+    "alpha": (8.0, 13.0),
+    "beta":  (13.0, 30.0),
+    "gamma": (30.0, 45.0),
+}
+
+
+# ===============================================================
+# EEG
+# ===============================================================
+def preprocess_eeg(
+    df: pd.DataFrame,
+    sampling_rate: int = 256,
+    hp_cutoff: float = 1.0,
+    lp_cutoff: float = 40.0,
+    notch_freq: float | None = 60.0,
+    notch_q: float = 30.0,
+    main_only: bool = True,
+) -> pd.DataFrame:
+    """
+    Preprocess EEG: zero-phase bandpass + optional powerline notch.
+
+    The bandpass also removes the standing DC bias that the Athena's ADC
+    produces (raw values are scaled to µV by `decode.EEG_SCALE` but sit
+    around ~700 µV).
+
+    Args:
+        df: Decoded EEG DataFrame from `decode_rawdata`. Must contain
+            the columns "time" and the EEG channels.
+        sampling_rate: EEG sampling rate (default 256 Hz).
+        hp_cutoff: High-pass cutoff in Hz (default 1.0).
+        lp_cutoff: Low-pass cutoff in Hz (default 40.0).
+        notch_freq: Powerline notch frequency in Hz, or None to skip.
+            Default 60.0 — pass 50.0 in Europe.
+        notch_q: Q factor for the IIR notch filter (default 30).
+        main_only: If True, drop the AUX channels and keep only
+            TP9/AF7/AF8/TP10.
+
+    Returns:
+        pd.DataFrame: Filtered EEG with the original "time" column and
+        the selected channels in the same order.
+    """
+    if df.empty:
+        return df
+
+    channels = list(EEG_MAIN_CHANNELS) if main_only else [c for c in EEG_CHANNELS if c in df.columns]
+    channels = [c for c in channels if c in df.columns]
+    if not channels:
+        return df.copy()
+
+    out = df[["time", *channels]].copy()
+    arr = out[channels].to_numpy().T  # shape (n_channels, n_samples)
+
+    arr = apply_butter_filter(arr, (hp_cutoff, lp_cutoff), sampling_rate, btype="band")
+
+    nyq = 0.5 * sampling_rate
+    if notch_freq is not None and notch_freq < nyq:
+        b, a = signal.iirnotch(notch_freq / nyq, notch_q)
+        arr = signal.filtfilt(b, a, arr, axis=-1)
+
+    out[channels] = arr.T
+    return out
+
+
+def eeg_band_power(
+    df: pd.DataFrame,
+    sampling_rate: int = 256,
+    bands: dict | None = None,
+    win_sec: float = 2.0,
+    step_sec: float = 1.0,
+) -> pd.DataFrame:
+    """
+    Windowed band power per EEG channel via Welch PSD + frequency integration.
+
+    Operates on a filtered EEG DataFrame (output of `preprocess_eeg`).
+    Each window's band power is computed as ∫ Pxx(f) df over the band.
+
+    Args:
+        df: Filtered EEG DataFrame with "time" and channel columns.
+        sampling_rate: EEG sampling rate (default 256 Hz).
+        bands: Optional mapping {name: (low_hz, high_hz)}. Defaults to
+            δ θ α β γ (Pernet et al. conventions).
+        win_sec: Window length in seconds (default 2.0).
+        step_sec: Hop in seconds (default 1.0).
+
+    Returns:
+        pd.DataFrame in long form with columns
+        ["time", "channel", "band", "power_uV2"].
+        Each row is the power in one band, one channel, at one window start.
+    """
+    if df.empty:
+        return pd.DataFrame(columns=["time", "channel", "band", "power_uV2"])
+
+    bands = bands or EEG_BANDS_DEFAULT
+    channels = [c for c in EEG_MAIN_CHANNELS if c in df.columns]
+    if not channels:
+        return pd.DataFrame(columns=["time", "channel", "band", "power_uV2"])
+
+    sig_arr = df[channels].to_numpy().T  # (n_ch, n_samp)
+    n_samp = sig_arr.shape[-1]
+    win = int(round(win_sec * sampling_rate))
+    step = int(round(step_sec * sampling_rate))
+    if n_samp < win:
+        return pd.DataFrame(columns=["time", "channel", "band", "power_uV2"])
+
+    starts = np.arange(0, n_samp - win + 1, step)
+    nperseg = min(win, max(sampling_rate, 64))
+
+    rows = []
+    for s in starts:
+        seg = sig_arr[:, s:s + win]
+        f, P = signal.welch(seg, fs=sampling_rate, nperseg=nperseg, axis=-1)
+        t = s / sampling_rate
+        for b_name, (lo, hi) in bands.items():
+            mask = (f >= lo) & (f < hi)
+            powers = np.trapezoid(P[:, mask], f[mask], axis=-1)
+            for j, ch in enumerate(channels):
+                rows.append({
+                    "time": float(t),
+                    "channel": ch,
+                    "band": b_name,
+                    "power_uV2": float(powers[j]),
+                })
+    return pd.DataFrame(rows)
+
+
+# ===============================================================
+# HRV  (consumes BVP from preprocess_ppg)
+# ===============================================================
+def hrv_from_bvp(
+    bvp: np.ndarray,
+    sampling_rate: int = 64,
+    min_hr_bpm: float = 30.0,
+    max_hr_bpm: float = 200.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Time + frequency domain HRV from a BVP signal.
+
+    Detects systolic peaks on the fused BVP returned by `preprocess_ppg`
+    (which already inverts the reflectance polarity so that systolic peaks
+    are maxima), filters physiologically implausible inter-beat intervals,
+    and computes the standard HRV indices.
+
+    Frequency-domain bands follow Task Force (1996):
+        VLF  0.003 - 0.04 Hz
+        LF   0.04  - 0.15 Hz
+        HF   0.15  - 0.40 Hz
+    The IBI tachogram is resampled to 4 Hz (linear interpolation) before
+    Welch PSD. Frequency-domain indices require >= 30 s of beats and are
+    returned as NaN otherwise.
+
+    Args:
+        bvp: 1-D BVP array (output of `preprocess_ppg`).
+        sampling_rate: BVP sampling rate (default 64 Hz, matches optics).
+        min_hr_bpm / max_hr_bpm: Physiologic IBI window. IBIs outside
+            [60000/max_hr_bpm, 60000/min_hr_bpm] ms are dropped.
+
+    Returns:
+        tuple[pd.DataFrame, pd.DataFrame]:
+          - summary: single-row DataFrame with
+              n_beats, mean_hr_bpm, mean_ibi_ms,
+              sdnn_ms, rmssd_ms, pnn50_pct,
+              vlf_ms2, lf_ms2, hf_ms2, total_power_ms2,
+              lf_hf_ratio, lf_nu, hf_nu
+          - ibis: per-beat DataFrame with columns [beat, ibi_ms]
+    """
+    empty_summary = pd.DataFrame()
+    empty_ibis = pd.DataFrame(columns=["beat", "ibi_ms"])
+
+    if bvp is None or len(bvp) == 0:
+        return empty_summary, empty_ibis
+
+    sig_arr = np.asarray(bvp, dtype=float).ravel()
+    # Drop NaNs at the head/tail rather than letting find_peaks see them.
+    finite = np.isfinite(sig_arr)
+    if not finite.any():
+        return empty_summary, empty_ibis
+    sig_arr = sig_arr[finite]
+
+    std = sig_arr.std()
+    if std < 1e-9:
+        return empty_summary, empty_ibis
+
+    min_dist = max(int(sampling_rate * 60.0 / max_hr_bpm), 1)
+    peaks, _ = signal.find_peaks(
+        sig_arr - sig_arr.mean(), distance=min_dist, prominence=0.5 * std,
+    )
+    if peaks.size < 4:
+        return empty_summary, empty_ibis
+
+    ibi_ms = np.diff(peaks) / sampling_rate * 1000.0
+    lo_ms = 60000.0 / max_hr_bpm
+    hi_ms = 60000.0 / min_hr_bpm
+    ibi_ms = ibi_ms[(ibi_ms > lo_ms) & (ibi_ms < hi_ms)]
+    if ibi_ms.size < 4:
+        return empty_summary, empty_ibis
+
+    diffs = np.diff(ibi_ms)
+    mean_ibi = float(ibi_ms.mean())
+    sdnn = float(ibi_ms.std(ddof=1))
+    rmssd = float(np.sqrt(np.mean(diffs ** 2)))
+    pnn50 = float(np.mean(np.abs(diffs) > 50.0) * 100.0)
+    mean_hr = 60000.0 / mean_ibi
+
+    # Frequency domain (Welch on 4 Hz resampled tachogram).
+    t_beats = np.cumsum(ibi_ms) / 1000.0
+    if len(t_beats) >= 16 and (t_beats[-1] - t_beats[0]) >= 30.0:
+        fs_resamp = 4.0
+        t_uniform = np.arange(t_beats[0], t_beats[-1], 1.0 / fs_resamp)
+        ibi_uniform = np.interp(t_uniform, t_beats, ibi_ms)
+        ibi_uniform -= ibi_uniform.mean()
+        nperseg = min(256, len(ibi_uniform))
+        f, Pxx = signal.welch(ibi_uniform, fs=fs_resamp, nperseg=nperseg)
+
+        def _bp(lo, hi):
+            m = (f >= lo) & (f < hi)
+            return float(np.trapezoid(Pxx[m], f[m])) if m.any() else float("nan")
+
+        vlf = _bp(0.003, 0.04)
+        lf = _bp(0.04, 0.15)
+        hf = _bp(0.15, 0.40)
+        lf_hf = lf / hf if (hf and hf > 0) else float("nan")
+        total = vlf + lf + hf
+        lf_nu = 100.0 * lf / (lf + hf) if (lf + hf) > 0 else float("nan")
+        hf_nu = 100.0 * hf / (lf + hf) if (lf + hf) > 0 else float("nan")
+    else:
+        vlf = lf = hf = total = lf_hf = lf_nu = hf_nu = float("nan")
+
+    summary = pd.DataFrame([{
+        "n_beats": int(len(ibi_ms) + 1),
+        "mean_hr_bpm": mean_hr,
+        "mean_ibi_ms": mean_ibi,
+        "sdnn_ms": sdnn,
+        "rmssd_ms": rmssd,
+        "pnn50_pct": pnn50,
+        "vlf_ms2": vlf,
+        "lf_ms2": lf,
+        "hf_ms2": hf,
+        "total_power_ms2": total,
+        "lf_hf_ratio": lf_hf,
+        "lf_nu": lf_nu,
+        "hf_nu": hf_nu,
+    }])
+    ibis = pd.DataFrame({"beat": np.arange(1, len(ibi_ms) + 1), "ibi_ms": ibi_ms})
+    return summary, ibis

--- a/experiments/analyze_eoec.py
+++ b/experiments/analyze_eoec.py
@@ -1,0 +1,185 @@
+"""Analyse an eyes-open / eyes-closed run.
+
+1. Runs the standard pipeline on raw.txt -> out/.
+2. Loads events.csv, aligns timestamps to the recording.
+3. Computes per-condition band power from filtered EEG.
+4. Writes condition_band_power.csv + eoec_report.pdf with:
+       - α (8-13 Hz) power per channel, open vs closed (the canonical test)
+       - PSD overlay per condition
+       - Open/closed ratio with statistical significance per channel (Welch's t-test)
+"""
+from __future__ import annotations
+import argparse
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy import stats
+
+from muse_pipeline.runner import run_pipeline
+from muse_pipeline.loaders import load_recording
+from muse_pipeline.preprocess import preprocess_all, EEG_MAIN
+from muse_pipeline.events import load_events, align_events, first_packet_iso
+from muse_pipeline.epochs import band_power_by_condition
+from muse_pipeline.features import EEG_BANDS
+
+
+def _sub_epoch(events: pd.DataFrame, epoch_s: float = 2.0) -> pd.DataFrame:
+    """Split each long block into sequential non-overlapping epoch_s sub-trials.
+    This is what gives us multiple samples per condition for statistics."""
+    rows = []
+    for _, ev in events.iterrows():
+        dur = float(ev["duration_s"]) if ev["duration_s"] else 0.0
+        if dur < epoch_s:
+            continue
+        n_sub = int(dur // epoch_s)
+        for k in range(n_sub):
+            rows.append({
+                "onset_iso": ev["onset_iso"],
+                "onset_s": float(ev["onset_s"]) + k * epoch_s,
+                "label": ev["label"],
+                "duration_s": epoch_s,
+                "notes": f"sub_{k}",
+            })
+    return pd.DataFrame(rows)
+
+
+def analyze(rundir: Path, epoch_s: float = 2.0) -> Path:
+    raw_txt = rundir / "raw.txt"
+    events_csv = rundir / "events.csv"
+    out = rundir / "analysis"
+    out.mkdir(exist_ok=True)
+
+    # 1) Full pipeline.
+    run_pipeline(raw_txt, out / "pipeline")
+
+    # 2) Reload filtered EEG (already saved by pipeline) so we don't recompute.
+    rec = load_recording(raw_txt)
+    pre = preprocess_all(rec)
+    sr = rec.sample_rates.get("EEG", 256.0)
+
+    # 3) Align events.
+    t0_iso = first_packet_iso(raw_txt)
+    events = load_events(events_csv)
+    events = align_events(events, t0_iso)
+    cond_events = events[events["label"].isin(["eyes_open", "eyes_closed"])].copy()
+    sub_events = _sub_epoch(cond_events, epoch_s=epoch_s)
+    sub_events.to_csv(out / "sub_events.csv", index=False)
+
+    # 4) Band power per sub-epoch.
+    bp = band_power_by_condition(pre.eeg, sub_events, sr=sr, bands=EEG_BANDS)
+    bp.to_csv(out / "condition_band_power.csv", index=False)
+
+    # 5) Stats: Welch's t-test, eyes_closed > eyes_open in alpha.
+    stat_rows = []
+    for band in EEG_BANDS:
+        for ch in [c for c in EEG_MAIN if c in pre.eeg.columns]:
+            sub = bp[(bp["band"] == band) & (bp["channel"] == ch)]
+            o = sub.loc[sub["label"] == "eyes_open", "power_uV2"].to_numpy()
+            c = sub.loc[sub["label"] == "eyes_closed", "power_uV2"].to_numpy()
+            if len(o) < 2 or len(c) < 2:
+                continue
+            t, p = stats.ttest_ind(c, o, equal_var=False)
+            stat_rows.append({
+                "band": band, "channel": ch,
+                "n_open": len(o), "n_closed": len(c),
+                "mean_open_uV2": float(o.mean()), "mean_closed_uV2": float(c.mean()),
+                "ratio_closed_over_open": float(c.mean() / o.mean()) if o.mean() > 0 else float("nan"),
+                "t": float(t), "p_value": float(p),
+            })
+    stats_df = pd.DataFrame(stat_rows).sort_values(["band", "channel"])
+    stats_df.to_csv(out / "stats.csv", index=False)
+
+    # 6) Plot.
+    fig, axes = plt.subplots(2, 2, figsize=(13, 10))
+    fig.suptitle(f"Eyes-open vs eyes-closed — {rundir.name}", fontsize=13)
+
+    # α power per channel, two boxes per channel.
+    ax = axes[0, 0]
+    alpha = bp[bp["band"] == "alpha"]
+    chans = sorted(alpha["channel"].unique())
+    open_data   = [alpha.loc[(alpha["channel"] == ch) & (alpha["label"] == "eyes_open"),   "power_uV2"].to_numpy() for ch in chans]
+    closed_data = [alpha.loc[(alpha["channel"] == ch) & (alpha["label"] == "eyes_closed"), "power_uV2"].to_numpy() for ch in chans]
+    x = np.arange(len(chans))
+    ax.boxplot(open_data,   positions=x - 0.18, widths=0.3, patch_artist=True,
+               boxprops=dict(facecolor="#9ec5fe"))
+    ax.boxplot(closed_data, positions=x + 0.18, widths=0.3, patch_artist=True,
+               boxprops=dict(facecolor="#f8b4b4"))
+    ax.set_xticks(x); ax.set_xticklabels(chans)
+    ax.set_title(f"Alpha (8-13 Hz) power per channel  •  {epoch_s:.0f}s epochs")
+    ax.set_ylabel("µV²")
+    ax.legend([plt.Rectangle((0,0),1,1,fc="#9ec5fe"), plt.Rectangle((0,0),1,1,fc="#f8b4b4")],
+              ["eyes_open", "eyes_closed"], loc="upper right")
+
+    # PSD overlay (whole-block PSD per condition).
+    ax = axes[0, 1]
+    from scipy import signal as _sig
+    for cond, color in [("eyes_open", "tab:blue"), ("eyes_closed", "tab:red")]:
+        blocks = events[events["label"] == cond]
+        psds_per_ch = {ch: [] for ch in chans}
+        for _, ev in blocks.iterrows():
+            onset = float(ev["onset_s"]); dur = float(ev["duration_s"])
+            t = pre.eeg["time"].to_numpy()
+            mask = (t >= onset) & (t < onset + dur)
+            if mask.sum() < int(sr): continue
+            for ch in chans:
+                seg = pre.eeg.loc[mask, ch].to_numpy()
+                f, P = _sig.welch(seg, fs=sr, nperseg=min(int(sr*2), len(seg)))
+                psds_per_ch[ch].append(P)
+        if not any(psds_per_ch.values()):
+            continue
+        # Average PSD across channels and blocks for a compact overlay.
+        avg = np.mean([np.mean(np.array(v), axis=0) for v in psds_per_ch.values() if v], axis=0)
+        ax.semilogy(f, avg, label=cond, color=color, lw=1.2)
+    ax.axvspan(8, 13, alpha=0.1, color="green")
+    ax.set_xlim(1, 40); ax.set_title("Channel-averaged PSD per condition  •  α band shaded")
+    ax.set_xlabel("Hz"); ax.set_ylabel("µV²/Hz"); ax.legend()
+
+    # Ratio closed/open with significance.
+    ax = axes[1, 0]
+    if not stats_df.empty:
+        alpha_stats = stats_df[stats_df["band"] == "alpha"]
+        sig = alpha_stats["p_value"] < 0.05
+        colors = ["#16a34a" if s else "#9ca3af" for s in sig]
+        ax.bar(alpha_stats["channel"], alpha_stats["ratio_closed_over_open"], color=colors)
+        ax.axhline(1.0, ls="--", color="k", lw=0.8)
+        for i, (_, r) in enumerate(alpha_stats.iterrows()):
+            ax.text(i, r["ratio_closed_over_open"] + 0.02,
+                    f"p={r['p_value']:.3g}", ha="center", fontsize=8)
+        ax.set_title("α power ratio (closed / open)  •  green = p<0.05 (Welch t-test)")
+        ax.set_ylabel("ratio")
+    else:
+        ax.text(0.5, 0.5, "not enough data", ha="center", va="center"); ax.set_axis_off()
+
+    # All bands ratio table.
+    ax = axes[1, 1]
+    ax.axis("off")
+    if not stats_df.empty:
+        pivot = stats_df.pivot(index="band", columns="channel", values="ratio_closed_over_open")
+        pivot = pivot.reindex(list(EEG_BANDS.keys()))
+        tbl = ax.table(cellText=np.round(pivot.values, 2),
+                       rowLabels=pivot.index, colLabels=pivot.columns,
+                       loc="center", cellLoc="center")
+        tbl.auto_set_font_size(False); tbl.set_fontsize(9); tbl.scale(1.0, 1.4)
+        ax.set_title("closed / open power ratio per band")
+
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    report = out / "eoec_report.pdf"
+    fig.savefig(report, dpi=120)
+    plt.close(fig)
+    print(f"wrote {report}")
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("rundir", type=Path, help="Directory holding raw.txt + events.csv")
+    p.add_argument("--epoch", type=float, default=2.0, help="Sub-epoch length in seconds (default 2.0)")
+    args = p.parse_args()
+    analyze(args.rundir, epoch_s=args.epoch)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/eyes_open_closed.py
+++ b/experiments/eyes_open_closed.py
@@ -1,0 +1,148 @@
+"""Cued eyes-open / eyes-closed recording.
+
+Spawns `OpenMuse record` as a subprocess to dump raw BLE packets to disk,
+while this script drives on-screen cues and writes a synchronised events.csv.
+
+Both files share the same wall-clock (UTC) timestamps, so events align with
+the recording by matching ISO timestamps after the fact.
+
+Default protocol:
+    5 s ready countdown
+    block 1: 30 s eyes open
+    block 2: 30 s eyes closed
+    block 3: 30 s eyes open
+    block 4: 30 s eyes closed
+    (= 125 s total)
+
+Usage:
+    python -m experiments.eyes_open_closed --address <muse-addr> --outdir runs/eoec_$(date +%Y%m%d_%H%M%S)
+"""
+from __future__ import annotations
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from muse_pipeline.events import make_event, save_events, now_iso
+from muse_pipeline.loaders import SIDECAR_NAME
+
+# Matches lines like: "Connected to device (firmware 3.1.23): battery 28.75%"
+_RE_DEVICE = re.compile(r"firmware\s+(\S+).*?battery\s+([\d.]+)", re.IGNORECASE)
+
+DEFAULT_BLOCKS = [
+    ("eyes_open",   30.0),
+    ("eyes_closed", 30.0),
+    ("eyes_open",   30.0),
+    ("eyes_closed", 30.0),
+]
+
+
+def _ready(seconds: int) -> None:
+    print(f"\nGet ready. Recording in...")
+    for i in range(seconds, 0, -1):
+        print(f"  {i}", flush=True)
+        time.sleep(1)
+
+
+def _print_cue(label: str, duration: float) -> None:
+    if label == "eyes_open":
+        msg = f"  ▸ EYES OPEN — fix gaze on a calm point   ({duration:.0f} s)"
+    elif label == "eyes_closed":
+        msg = f"  ▸ EYES CLOSED — relax, breathe normally  ({duration:.0f} s)"
+    else:
+        msg = f"  ▸ {label}                                ({duration:.0f} s)"
+    print("\n" + msg, flush=True)
+
+
+def run_protocol(address: str, outdir: Path, blocks=DEFAULT_BLOCKS, ready_s: int = 5,
+                 record_cmd: str = "OpenMuse") -> Path:
+    if shutil.which(record_cmd) is None:
+        sys.exit(f"`{record_cmd}` not on PATH — activate the muse conda env first.")
+    outdir.mkdir(parents=True, exist_ok=True)
+    raw_path = outdir / "raw.txt"
+    events_path = outdir / "events.csv"
+
+    total_s = ready_s + sum(d for _, d in blocks) + 2  # +2 s tail buffer
+    cmd = [record_cmd, "record", "--address", address, "--duration", str(int(total_s)),
+           "--outfile", str(raw_path)]
+    print(f"Spawning recorder: {' '.join(cmd)}\n(total {total_s} s)")
+    env = {"PYTHONUNBUFFERED": "1"}
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        env={**__import__("os").environ, **env},
+    )
+
+    # Tee stdout: print live AND parse out firmware/battery on the first "Connected to device" line.
+    captured = {"firmware": None, "battery_start_pct": None}
+
+    def _pump():
+        for line in proc.stdout:  # type: ignore[union-attr]
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            if captured["firmware"] is None:
+                m = _RE_DEVICE.search(line)
+                if m:
+                    captured["firmware"] = m.group(1)
+                    captured["battery_start_pct"] = float(m.group(2))
+
+    pump_thread = threading.Thread(target=_pump, daemon=True)
+    pump_thread.start()
+
+    events: list[dict] = []
+    try:
+        events.append(make_event("session_start", duration_s=0.0))
+        _ready(ready_s)
+        for label, dur in blocks:
+            iso = now_iso()
+            _print_cue(label, dur)
+            events.append(make_event(label, duration_s=dur, onset_iso=iso))
+            time.sleep(dur)
+        events.append(make_event("session_end", duration_s=0.0))
+        print("\nDone cuing. Waiting for recorder to flush...")
+        proc.wait(timeout=total_s + 30)
+    except KeyboardInterrupt:
+        print("\nInterrupted; stopping recorder.")
+        proc.terminate()
+        proc.wait(timeout=10)
+        events.append(make_event("session_aborted", duration_s=0.0))
+
+    save_events(events, events_path)
+
+    # Sidecar metadata next to raw.txt so the loader can pick up firmware/device info.
+    sidecar = {
+        "device_address": address,
+        "firmware": captured["firmware"],
+        "battery_start_pct": captured["battery_start_pct"],
+        "protocol": "eyes_open_closed",
+        "blocks": [{"label": l, "duration_s": d} for l, d in blocks],
+    }
+    (outdir / SIDECAR_NAME).write_text(json.dumps(sidecar, indent=2))
+
+    print(f"\nRecording: {raw_path}")
+    print(f"Events:    {events_path}")
+    print(f"Metadata:  {outdir / SIDECAR_NAME}")
+    return outdir
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--address", required=True, help="Muse address (CoreBluetooth UUID on macOS)")
+    p.add_argument("--outdir",  required=True, type=Path, help="Where to write raw.txt + events.csv")
+    p.add_argument("--ready",   type=int, default=5, help="Pre-roll countdown in seconds (default 5)")
+    p.add_argument("--block",   type=float, default=30.0, help="Block duration in seconds (default 30)")
+    p.add_argument("--n-blocks", type=int, default=4, help="Number of alternating O/C blocks (default 4)")
+    p.add_argument("--first",   choices=("open", "closed"), default="open")
+    args = p.parse_args()
+
+    seq = ["eyes_open", "eyes_closed"] if args.first == "open" else ["eyes_closed", "eyes_open"]
+    blocks = [(seq[i % 2], args.block) for i in range(args.n_blocks)]
+    run_protocol(args.address, args.outdir, blocks=blocks, ready_s=args.ready)
+
+
+if __name__ == "__main__":
+    main()

--- a/muse_pipeline/__init__.py
+++ b/muse_pipeline/__init__.py
@@ -1,0 +1,30 @@
+"""Muse S Athena offline analysis pipeline.
+
+Stages:
+    loaders     raw .txt (OpenMuse record output)  -> decoded DataFrames per modality
+    preprocess  filter / scale / derive            -> cleaned DataFrames
+    features    band power / HR / motion stats     -> feature DataFrames
+    quality     saturation / SQI / summary         -> per-modality QC dicts
+    export      parquet + MNE-FIF + QC report PDF  -> files on disk
+
+Default sample rates (from OpenMuse decoder):
+    EEG     256 Hz   8 channels (TP9, AF7, AF8, TP10 + AUX_1..4)
+    ACCGYRO  52 Hz   ACC_X/Y/Z (g), GYRO_X/Y/Z (deg/s)
+    OPTICS   64 Hz   16 channels (4 optodes x 4 wavelengths)
+    BATTERY  ~1 Hz   battery_percent
+"""
+from .loaders import load_recording
+from .preprocess import preprocess_all
+from .features import compute_features
+from .quality import compute_quality
+from .export import export_all
+from .runner import run_pipeline
+
+__all__ = [
+    "load_recording",
+    "preprocess_all",
+    "compute_features",
+    "compute_quality",
+    "export_all",
+    "run_pipeline",
+]

--- a/muse_pipeline/__main__.py
+++ b/muse_pipeline/__main__.py
@@ -1,0 +1,23 @@
+"""CLI: python -m muse_pipeline run <input.txt> <outdir>"""
+import argparse
+from pathlib import Path
+from .runner import run_pipeline
+
+
+def main():
+    p = argparse.ArgumentParser(prog="muse_pipeline")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="Run pipeline on an OpenMuse .txt recording")
+    r.add_argument("input", type=Path, help="Input .txt from `OpenMuse record`")
+    r.add_argument("outdir", type=Path, help="Output directory for artifacts")
+    r.add_argument("--firmware", type=str, default=None,
+                   help="Device firmware (e.g. 3.1.23). Overrides recording_metadata.json.")
+
+    args = p.parse_args()
+    if args.cmd == "run":
+        run_pipeline(args.input, args.outdir, firmware=args.firmware)
+
+
+if __name__ == "__main__":
+    main()

--- a/muse_pipeline/epochs.py
+++ b/muse_pipeline/epochs.py
@@ -1,0 +1,107 @@
+"""Epoching: turn continuous EEG + events into MNE Epochs and per-condition band power.
+
+Two entry points:
+    epoch_eeg(eeg_filt, events, tmin, tmax)      -> mne.Epochs
+    band_power_by_condition(eeg_filt, events, ...) -> tidy DataFrame
+"""
+from __future__ import annotations
+from typing import Dict, Iterable, Tuple
+import numpy as np
+import pandas as pd
+from scipy import signal
+
+from .preprocess import EEG_MAIN
+from .export import MUSE_MNE_MONTAGE
+from .features import EEG_BANDS
+
+
+def _to_mne_raw(eeg_filt: pd.DataFrame, sr: float):
+    import mne
+    chans = [c for c in EEG_MAIN if c in eeg_filt.columns]
+    arr = eeg_filt[chans].to_numpy().T * 1e-6  # MNE expects volts
+    ch_names = [MUSE_MNE_MONTAGE[c] for c in chans]
+    info = mne.create_info(ch_names=ch_names, sfreq=sr, ch_types=["eeg"] * len(ch_names))
+    raw = mne.io.RawArray(arr, info, verbose=False)
+    try:
+        raw.set_montage("standard_1020", on_missing="ignore", verbose=False)
+    except Exception:
+        pass
+    return raw
+
+
+def _events_to_mne_array(events: pd.DataFrame, sr: float) -> Tuple[np.ndarray, Dict[str, int]]:
+    """Convert tidy events df to MNE (samples, prev, code) array + label->code map."""
+    labels = sorted(events["label"].dropna().unique().tolist())
+    label_to_code = {lab: i + 1 for i, lab in enumerate(labels)}
+    rows = []
+    for _, ev in events.iterrows():
+        s = int(round(float(ev["onset_s"]) * sr))
+        rows.append([s, 0, label_to_code[ev["label"]]])
+    arr = np.array(rows, dtype=int) if rows else np.empty((0, 3), dtype=int)
+    return arr, label_to_code
+
+
+def epoch_eeg(eeg_filt: pd.DataFrame, events: pd.DataFrame, sr: float,
+              tmin: float = 0.0, tmax: float = 5.0, baseline=None,
+              reject_uv: float | None = 200.0):
+    """Build an mne.Epochs from filtered EEG and event onsets.
+
+    reject_uv: peak-to-peak amplitude rejection threshold (µV). Pass None to disable.
+    """
+    import mne
+    raw = _to_mne_raw(eeg_filt, sr)
+    ev_arr, label_map = _events_to_mne_array(events, sr)
+    reject = {"eeg": reject_uv * 1e-6} if reject_uv else None
+    epochs = mne.Epochs(
+        raw, ev_arr, event_id=label_map,
+        tmin=tmin, tmax=tmax, baseline=baseline, reject=reject,
+        preload=True, verbose=False,
+    )
+    return epochs
+
+
+def _band_power(arr: np.ndarray, sr: float, lo: float, hi: float, nperseg: int) -> np.ndarray:
+    """Welch-PSD band power. arr shape (n_ch, n_samp). Returns shape (n_ch,)."""
+    f, P = signal.welch(arr, fs=sr, nperseg=min(nperseg, arr.shape[-1]), axis=-1)
+    mask = (f >= lo) & (f < hi)
+    return np.trapezoid(P[:, mask], f[mask], axis=-1)
+
+
+def band_power_by_condition(
+    eeg_filt: pd.DataFrame, events: pd.DataFrame, sr: float,
+    bands: Dict[str, Tuple[float, float]] = EEG_BANDS,
+) -> pd.DataFrame:
+    """For each event, compute per-channel band power over [onset_s, onset_s + duration_s].
+
+    Returns long-form DataFrame: epoch_idx, label, channel, band, power_uV2, duration_s.
+    """
+    if eeg_filt.empty or events.empty:
+        return pd.DataFrame()
+    chans = [c for c in EEG_MAIN if c in eeg_filt.columns]
+    t = eeg_filt["time"].to_numpy()
+    data = eeg_filt[chans].to_numpy().T  # (n_ch, n_samp)
+    nperseg = int(sr * 2)  # 2 s windows -> ~0.5 Hz bins
+
+    rows = []
+    for i, ev in events.iterrows():
+        onset = float(ev["onset_s"])
+        dur = float(ev["duration_s"]) if ev["duration_s"] and not np.isnan(ev["duration_s"]) else 0.0
+        if dur <= 0:
+            continue
+        end = onset + dur
+        mask = (t >= onset) & (t < end)
+        if mask.sum() < int(sr):  # need >=1 s of data
+            continue
+        seg = data[:, mask]
+        for band, (lo, hi) in bands.items():
+            powers = _band_power(seg, sr, lo, hi, nperseg=nperseg)
+            for j, ch in enumerate(chans):
+                rows.append({
+                    "epoch_idx": int(i),
+                    "label": ev["label"],
+                    "channel": ch,
+                    "band": band,
+                    "power_uV2": float(powers[j]),
+                    "duration_s": dur,
+                })
+    return pd.DataFrame(rows)

--- a/muse_pipeline/events.py
+++ b/muse_pipeline/events.py
@@ -1,0 +1,70 @@
+"""Event markers for epoching / condition analysis.
+
+An events CSV has columns:
+    onset_iso     ISO 8601 wall-clock UTC string (matches OpenMuse `record` packet timestamps)
+    onset_s       seconds since recording start (set by `align_events`)
+    label         short string condition name (e.g. "eyes_open", "stimulus_face")
+    duration_s    block / trial duration (0 for instantaneous markers)
+    notes         free-form metadata (optional)
+"""
+from __future__ import annotations
+from datetime import datetime, timezone
+from pathlib import Path
+import pandas as pd
+
+EVENT_COLUMNS = ("onset_iso", "onset_s", "label", "duration_s", "notes")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def make_event(label: str, duration_s: float = 0.0, notes: str = "", onset_iso: str | None = None) -> dict:
+    return {
+        "onset_iso": onset_iso or now_iso(),
+        "onset_s": float("nan"),
+        "label": label,
+        "duration_s": float(duration_s),
+        "notes": notes,
+    }
+
+
+def save_events(events: list[dict] | pd.DataFrame, path: Path) -> Path:
+    df = events if isinstance(events, pd.DataFrame) else pd.DataFrame(events)
+    for col in EVENT_COLUMNS:
+        if col not in df.columns:
+            df[col] = "" if col in ("onset_iso", "label", "notes") else float("nan")
+    df = df[list(EVENT_COLUMNS)]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+    return path
+
+
+def load_events(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "notes" in df.columns:
+        df["notes"] = df["notes"].fillna("")
+    return df
+
+
+def align_events(events: pd.DataFrame, recording_t0_iso: str) -> pd.DataFrame:
+    """Fill the onset_s column using the recording's wall-clock t0."""
+    if events.empty:
+        return events
+    t0 = datetime.fromisoformat(recording_t0_iso)
+    out = events.copy()
+    out["onset_s"] = [
+        (datetime.fromisoformat(iso) - t0).total_seconds()
+        for iso in out["onset_iso"]
+    ]
+    return out
+
+
+def first_packet_iso(record_txt_path: Path) -> str:
+    """Return the ISO timestamp of the first packet in an OpenMuse .txt recording."""
+    with open(record_txt_path) as f:
+        first_line = f.readline().rstrip("\n")
+    if not first_line:
+        raise ValueError(f"Empty recording file: {record_txt_path}")
+    iso = first_line.split("\t", 1)[0]
+    return iso

--- a/muse_pipeline/export.py
+++ b/muse_pipeline/export.py
@@ -1,0 +1,241 @@
+"""Export decoded / preprocessed / feature data to disk + a one-page QC PDF."""
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict
+import json
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from .loaders import Recording
+from .preprocess import Preprocessed, EEG_MAIN
+from .features import Features
+
+# Standard 10-20 sensor positions for Muse main channels (used by MNE).
+MUSE_MNE_MONTAGE = {
+    "EEG_TP9":  "TP9",
+    "EEG_AF7":  "AF7",
+    "EEG_AF8":  "AF8",
+    "EEG_TP10": "TP10",
+}
+
+
+def _save_parquet_or_csv(df: pd.DataFrame, base: Path) -> Path | None:
+    """Try Parquet, fall back to CSV if pyarrow/fastparquet missing. Empty df -> None."""
+    if df.empty:
+        return None
+    try:
+        out = base.with_suffix(".parquet")
+        df.to_parquet(out, index=False)
+        return out
+    except (ImportError, ValueError):
+        out = base.with_suffix(".csv")
+        df.to_csv(out, index=False)
+        return out
+
+
+def export_dataframes(
+    rec: Recording, pre: Preprocessed, feats: Features, qc: Dict[str, pd.DataFrame], outdir: Path,
+) -> Dict[str, Path]:
+    outdir.mkdir(parents=True, exist_ok=True)
+    written: Dict[str, Path] = {}
+
+    def _record(key: str, p: Path | None):
+        if p is not None:
+            written[key] = p
+
+    # Decoded raw per modality.
+    for name, df in [("eeg_raw", rec.eeg), ("accgyro_raw", rec.accgyro),
+                     ("optics_raw", rec.optics), ("battery", rec.battery)]:
+        _record(name, _save_parquet_or_csv(df, outdir / name))
+
+    # Preprocessed.
+    _record("eeg_filtered",     _save_parquet_or_csv(pre.eeg, outdir / "eeg_filtered"))
+    _record("accgyro_features", _save_parquet_or_csv(pre.accgyro_features, outdir / "accgyro_features"))
+    _record("fnirs",            _save_parquet_or_csv(pre.fnirs, outdir / "fnirs"))
+    if pre.bvp.size:
+        sr = pre.sample_rates.get("OPTICS", 64.0)
+        bvp_df = pd.DataFrame({"time": np.arange(len(pre.bvp)) / sr, "bvp": pre.bvp})
+        _record("bvp", _save_parquet_or_csv(bvp_df, outdir / "bvp"))
+
+    # Features.
+    _record("eeg_band_power", _save_parquet_or_csv(feats.eeg_band_power, outdir / "eeg_band_power"))
+    _record("eeg_psd",        _save_parquet_or_csv(feats.eeg_psd, outdir / "eeg_psd"))
+    _record("heart_rate",     _save_parquet_or_csv(feats.heart_rate, outdir / "heart_rate"))
+    _record("hrv",            _save_parquet_or_csv(feats.hrv, outdir / "hrv"))
+    _record("ibis",           _save_parquet_or_csv(feats.ibis, outdir / "ibis"))
+    _record("motion",         _save_parquet_or_csv(feats.motion, outdir / "motion"))
+
+    # QC tables.
+    qc_dir = outdir / "qc"
+    qc_dir.mkdir(exist_ok=True)
+    for name, df in qc.items():
+        _record(f"qc_{name}", _save_parquet_or_csv(df, qc_dir / name))
+
+    # Metadata sidecar.
+    meta = {
+        "source": rec.source,
+        "device_address": rec.device_address,
+        "firmware": rec.firmware,
+        "battery_start_pct": rec.battery_start_pct,
+        "sample_rates_hz": rec.sample_rates,
+        "fnirs_info": {k: v for k, v in pre.fnirs_info.items() if isinstance(v, (str, int, float, list, dict))},
+        "bvp_info": {k: v for k, v in pre.bvp_info.items() if isinstance(v, (str, int, float, list, dict))},
+        "experimental_notices": [
+            (
+                "fNIRS outputs (Muse_OPTICS -> HbO/HbR/HbDiff) are EXPERIMENTAL. "
+                "The maintainer of OpenMuse (issue #23, 2026-01-29) notes that the "
+                "optics-to-fNIRS computation is still unclear and unvalidated, and a "
+                "recent firmware update changed optics behavior. Use HbO/HbR values "
+                "as a research signal, not as a measurement. EEG, IMU, BVP/HR/HRV are "
+                "unaffected."
+            ),
+        ],
+    }
+    (outdir / "metadata.json").write_text(json.dumps(meta, indent=2, default=str))
+    written["metadata"] = outdir / "metadata.json"
+    return written
+
+
+def export_mne_fif(eeg_filt: pd.DataFrame, sr: float, path: Path) -> Path | None:
+    """Export filtered EEG to a MNE Raw FIF file with a 10-20 montage."""
+    if eeg_filt.empty:
+        return None
+    try:
+        import mne
+    except ImportError:
+        return None
+    chans = [c for c in EEG_MAIN if c in eeg_filt.columns]
+    arr = eeg_filt[chans].to_numpy().T * 1e-6  # MNE expects volts
+    ch_names = [MUSE_MNE_MONTAGE[c] for c in chans]
+    info = mne.create_info(ch_names=ch_names, sfreq=sr, ch_types=["eeg"] * len(ch_names))
+    raw = mne.io.RawArray(arr, info, verbose=False)
+    try:
+        raw.set_montage("standard_1020", on_missing="ignore", verbose=False)
+    except Exception:
+        pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw.save(path, overwrite=True, verbose=False)
+    return path
+
+
+def qc_report(rec: Recording, pre: Preprocessed, feats: Features, qc: Dict[str, pd.DataFrame], path: Path) -> Path:
+    """One-page multipanel QC plot."""
+    fig, axes = plt.subplots(4, 2, figsize=(14, 16))
+    fw = f" • firmware {rec.firmware}" if rec.firmware else ""
+    fig.suptitle(f"Muse S Athena QC — {Path(rec.source).name}{fw}", fontsize=14)
+    fig.text(
+        0.5, 0.965,
+        "fNIRS outputs are EXPERIMENTAL — see OpenMuse issue #23. "
+        "EEG, IMU, BVP/HR/HRV are validated signal processing.",
+        ha="center", fontsize=9, color="#b91c1c",
+    )
+
+    # 1) Filtered EEG, first 10 s
+    ax = axes[0, 0]
+    if not pre.eeg.empty:
+        chans = [c for c in EEG_MAIN if c in pre.eeg.columns]
+        sr = rec.sample_rates.get("EEG", 256.0)
+        n = min(int(sr * 10), len(pre.eeg))
+        t = pre.eeg["time"].to_numpy()[:n]
+        for i, ch in enumerate(chans):
+            ax.plot(t, pre.eeg[ch].to_numpy()[:n] + i * 200, lw=0.6, label=ch)
+        ax.set_title("Filtered EEG (1-40 Hz, 60 Hz notch) — first 10 s, offset 200 µV/ch")
+        ax.set_xlabel("time (s)"); ax.set_ylabel("µV (offset)")
+        ax.legend(loc="upper right", fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no EEG", ha="center", va="center"); ax.set_axis_off()
+
+    # 2) EEG mean PSD
+    ax = axes[0, 1]
+    if not feats.eeg_psd.empty:
+        for ch, sub in feats.eeg_psd.groupby("channel"):
+            ax.semilogy(sub["freq_hz"], sub["power_uV2_per_Hz"], lw=0.8, label=ch)
+        ax.set_xlim(0, 50); ax.set_title("EEG mean PSD")
+        ax.set_xlabel("Hz"); ax.set_ylabel("µV²/Hz")
+        ax.legend(fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no PSD", ha="center", va="center"); ax.set_axis_off()
+
+    # 3) Band power over time, alpha as a representative band, all channels
+    ax = axes[1, 0]
+    if not feats.eeg_band_power.empty:
+        alpha = feats.eeg_band_power[feats.eeg_band_power["band"] == "alpha"]
+        for ch, sub in alpha.groupby("channel"):
+            ax.plot(sub["time"], sub["power_uV2"], label=ch, lw=0.9)
+        ax.set_title("Alpha (8-13 Hz) band power over time")
+        ax.set_xlabel("time (s)"); ax.set_ylabel("µV²"); ax.legend(fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no band power", ha="center", va="center"); ax.set_axis_off()
+
+    # 4) ACC + GYRO magnitudes
+    ax = axes[1, 1]
+    if not pre.accgyro_features.empty:
+        ax.plot(pre.accgyro_features["time"], pre.accgyro_features["ACC_MAG"], label="|ACC| (g)", lw=0.8)
+        ax2 = ax.twinx()
+        ax2.plot(pre.accgyro_features["time"], pre.accgyro_features["GYRO_MAG"], color="tab:orange", label="|GYRO| (°/s)", lw=0.8)
+        ax.set_title("Movement"); ax.set_xlabel("time (s)")
+        ax.set_ylabel("|ACC| g"); ax2.set_ylabel("|GYRO| °/s")
+    else:
+        ax.text(0.5, 0.5, "no IMU", ha="center", va="center"); ax.set_axis_off()
+
+    # 5) BVP
+    ax = axes[2, 0]
+    if pre.bvp.size:
+        sr = rec.sample_rates.get("OPTICS", 64.0)
+        n = min(int(sr * 30), len(pre.bvp))
+        t = np.arange(n) / sr
+        ax.plot(t, pre.bvp[:n], lw=0.8)
+        ax.set_title("Fused BVP — first 30 s"); ax.set_xlabel("time (s)")
+    else:
+        ax.text(0.5, 0.5, "no BVP", ha="center", va="center"); ax.set_axis_off()
+
+    # 6) Heart rate over time
+    ax = axes[2, 1]
+    if not feats.heart_rate.empty:
+        ax.plot(feats.heart_rate["window_start_s"], feats.heart_rate["hr_bpm"], "-o", ms=3)
+        ax.set_title("Heart rate (BVP peak count)")
+        ax.set_xlabel("window start (s)"); ax.set_ylabel("bpm")
+    else:
+        ax.text(0.5, 0.5, "no HR", ha="center", va="center"); ax.set_axis_off()
+
+    # 7) fNIRS HbDiff per position  (EXPERIMENTAL)
+    ax = axes[3, 0]
+    if not pre.fnirs.empty:
+        cols = [c for c in pre.fnirs.columns if c.endswith("_HbDiff")]
+        for c in cols:
+            ax.plot(pre.fnirs["time"], pre.fnirs[c], label=c, lw=0.8)
+        ax.set_title("fNIRS HbDiff per position (HbO - HbR)  [EXPERIMENTAL]", color="#b91c1c")
+        ax.set_xlabel("time (s)"); ax.set_ylabel("µM"); ax.legend(fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no fNIRS", ha="center", va="center"); ax.set_axis_off()
+
+    # 8) EEG quality bars
+    ax = axes[3, 1]
+    if not qc.get("eeg", pd.DataFrame()).empty:
+        eeg_q = qc["eeg"]
+        ax.bar(eeg_q["channel"], eeg_q["sqi"])
+        ax.set_ylim(0, 1); ax.set_title("EEG SQI (0=bad, 1=good)")
+        ax.set_ylabel("SQI")
+        for i, sat in enumerate(eeg_q["saturation_pct"]):
+            ax.text(i, eeg_q["sqi"].iloc[i] + 0.02, f"{sat:.0f}% sat", ha="center", fontsize=7)
+    else:
+        ax.text(0.5, 0.5, "no EEG QC", ha="center", va="center"); ax.set_axis_off()
+
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, dpi=120)
+    plt.close(fig)
+    return path
+
+
+def export_all(rec: Recording, pre: Preprocessed, feats: Features, qc: Dict[str, pd.DataFrame], outdir: Path) -> Dict[str, Path]:
+    outdir = Path(outdir)
+    written = export_dataframes(rec, pre, feats, qc, outdir)
+    fif = export_mne_fif(pre.eeg, rec.sample_rates.get("EEG", 256.0), outdir / "eeg-raw.fif")
+    if fif is not None:
+        written["mne_fif"] = fif
+    written["qc_pdf"] = qc_report(rec, pre, feats, qc, outdir / "qc_report.pdf")
+    return written

--- a/muse_pipeline/features.py
+++ b/muse_pipeline/features.py
@@ -1,0 +1,236 @@
+"""Feature extraction: EEG band power, heart rate, motion stats."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+import numpy as np
+import pandas as pd
+from scipy import signal
+
+from .preprocess import Preprocessed, EEG_MAIN
+
+EEG_BANDS: Dict[str, Tuple[float, float]] = {
+    "delta": (1.0, 4.0),
+    "theta": (4.0, 8.0),
+    "alpha": (8.0, 13.0),
+    "beta":  (13.0, 30.0),
+    "gamma": (30.0, 45.0),
+}
+
+
+@dataclass
+class Features:
+    eeg_band_power: pd.DataFrame      # long-form: time, channel, band, power_uV2
+    eeg_psd: pd.DataFrame             # full PSD averaged over recording (channel, freq, power)
+    heart_rate: pd.DataFrame          # window_start, hr_bpm, n_peaks
+    hrv: pd.DataFrame                 # single-row time + frequency domain HRV summary
+    ibis: pd.DataFrame                # per-beat inter-beat intervals (ms)
+    motion: pd.DataFrame              # single-row summary
+    sample_rates: Dict[str, float] = field(default_factory=dict)
+
+
+def _windowed_band_power(
+    sig_arr: np.ndarray, sr: float, win_sec: float, step_sec: float,
+) -> Tuple[np.ndarray, Dict[str, np.ndarray], np.ndarray, np.ndarray]:
+    """Return (window_starts, band_power_dict[band->(n_win,n_ch)], freqs, mean_psd[n_ch,n_freq])."""
+    n_samp = sig_arr.shape[-1]
+    win = int(round(win_sec * sr))
+    step = int(round(step_sec * sr))
+    if n_samp < win:
+        return np.array([]), {b: np.empty((0, sig_arr.shape[0])) for b in EEG_BANDS}, np.array([]), np.empty((sig_arr.shape[0], 0))
+
+    starts = np.arange(0, n_samp - win + 1, step)
+    n_win = len(starts)
+    n_ch = sig_arr.shape[0]
+
+    # Welch nperseg: cap at win, but at least 1s of data so we get ~1 Hz bins.
+    nperseg = min(win, max(int(sr), 64))
+    bp = {b: np.zeros((n_win, n_ch)) for b in EEG_BANDS}
+    psd_accum = None
+    freqs = None
+
+    for w_idx, s in enumerate(starts):
+        seg = sig_arr[:, s:s + win]
+        f, P = signal.welch(seg, fs=sr, nperseg=nperseg, axis=-1)
+        if psd_accum is None:
+            psd_accum = np.zeros((n_ch, len(f)))
+            freqs = f
+        psd_accum += P
+        for b_name, (lo, hi) in EEG_BANDS.items():
+            mask = (f >= lo) & (f < hi)
+            bp[b_name][w_idx] = np.trapezoid(P[:, mask], f[mask], axis=-1)
+
+    psd_mean = psd_accum / n_win
+    window_starts = starts / sr
+    return window_starts, bp, freqs, psd_mean
+
+
+def eeg_features(eeg_df: pd.DataFrame, sr: float, win_sec: float = 2.0, step_sec: float = 1.0):
+    """Compute band power per window + recording-mean PSD."""
+    if eeg_df.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    chans = [c for c in eeg_df.columns if c != "time" and c in EEG_MAIN]
+    arr = eeg_df[chans].to_numpy().T  # (n_ch, n_samp)
+    starts, bp, freqs, psd = _windowed_band_power(arr, sr, win_sec, step_sec)
+
+    rows = []
+    for i, t in enumerate(starts):
+        for j, ch in enumerate(chans):
+            for b_name in EEG_BANDS:
+                rows.append({
+                    "time": float(t),
+                    "channel": ch,
+                    "band": b_name,
+                    "power_uV2": float(bp[b_name][i, j]),
+                })
+    bp_df = pd.DataFrame(rows)
+
+    psd_rows = []
+    for j, ch in enumerate(chans):
+        for k, f in enumerate(freqs):
+            psd_rows.append({"channel": ch, "freq_hz": float(f), "power_uV2_per_Hz": float(psd[j, k])})
+    psd_df = pd.DataFrame(psd_rows)
+    return bp_df, psd_df
+
+
+def heart_rate_from_bvp(
+    bvp: np.ndarray, sr: float, win_sec: float = 10.0, step_sec: float = 5.0,
+) -> pd.DataFrame:
+    """Estimate HR per sliding window via peak detection on the BVP."""
+    if bvp.size == 0:
+        return pd.DataFrame()
+    bvp = np.asarray(bvp).ravel()
+    win = int(round(win_sec * sr))
+    step = int(round(step_sec * sr))
+    if len(bvp) < win:
+        return pd.DataFrame()
+
+    rows = []
+    # min_distance corresponds to ~220 bpm upper bound (avoid double-peaks).
+    min_dist = max(int(sr * 60.0 / 220.0), 1)
+    for s in range(0, len(bvp) - win + 1, step):
+        seg = bvp[s:s + win]
+        seg = seg - seg.mean()
+        std = seg.std()
+        if std < 1e-9:
+            continue
+        peaks, _ = signal.find_peaks(seg, distance=min_dist, prominence=0.5 * std)
+        n_peaks = len(peaks)
+        hr_bpm = n_peaks * 60.0 / win_sec if n_peaks > 0 else float("nan")
+        rows.append({
+            "window_start_s": s / sr,
+            "hr_bpm": hr_bpm,
+            "n_peaks": int(n_peaks),
+        })
+    return pd.DataFrame(rows)
+
+
+def _bvp_peaks(bvp: np.ndarray, sr: float) -> np.ndarray:
+    """Detect BVP peaks; reject outlier IBIs > 3 SD."""
+    if bvp.size == 0:
+        return np.array([], dtype=int)
+    sig = bvp - bvp.mean()
+    std = sig.std()
+    if std < 1e-9:
+        return np.array([], dtype=int)
+    min_dist = max(int(sr * 60.0 / 220.0), 1)  # >=220 bpm cap
+    peaks, _ = signal.find_peaks(sig, distance=min_dist, prominence=0.5 * std)
+    return peaks
+
+
+def hrv_from_bvp(bvp: np.ndarray, sr: float) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Time + frequency domain HRV summary from a BVP signal.
+
+    Returns (summary_df, ibis_df). IBIs in milliseconds.
+    Frequency-domain bands (Task Force 1996):
+        VLF 0.003-0.04, LF 0.04-0.15, HF 0.15-0.40 Hz
+    """
+    peaks = _bvp_peaks(np.asarray(bvp).ravel(), sr)
+    if peaks.size < 4:
+        return pd.DataFrame(), pd.DataFrame()
+    ibi_s = np.diff(peaks) / sr
+    ibi_ms = ibi_s * 1000.0
+
+    # Drop physiologically implausible IBIs (clip to 300-2000 ms = 30-200 bpm).
+    plausible = (ibi_ms > 300) & (ibi_ms < 2000)
+    ibi_ms = ibi_ms[plausible]
+    if ibi_ms.size < 4:
+        return pd.DataFrame(), pd.DataFrame()
+    diffs = np.diff(ibi_ms)
+
+    mean_ibi = float(ibi_ms.mean())
+    sdnn = float(ibi_ms.std(ddof=1))
+    rmssd = float(np.sqrt(np.mean(diffs ** 2)))
+    pnn50 = float(np.mean(np.abs(diffs) > 50.0) * 100.0)
+    mean_hr = 60000.0 / mean_ibi
+
+    # Frequency domain: resample IBI series to 4 Hz then Welch.
+    t_beats = np.cumsum(ibi_ms) / 1000.0
+    if len(t_beats) >= 16 and t_beats[-1] - t_beats[0] >= 30.0:
+        fs_resamp = 4.0
+        t_uniform = np.arange(t_beats[0], t_beats[-1], 1.0 / fs_resamp)
+        ibi_uniform = np.interp(t_uniform, t_beats, ibi_ms)
+        ibi_uniform -= ibi_uniform.mean()
+        nperseg = min(256, len(ibi_uniform))
+        f, Pxx = signal.welch(ibi_uniform, fs=fs_resamp, nperseg=nperseg)
+        def _bp(lo, hi):
+            m = (f >= lo) & (f < hi)
+            return float(np.trapezoid(Pxx[m], f[m])) if m.any() else float("nan")
+        vlf = _bp(0.003, 0.04)
+        lf = _bp(0.04, 0.15)
+        hf = _bp(0.15, 0.40)
+        lf_hf = lf / hf if hf and hf > 0 else float("nan")
+        total = vlf + lf + hf
+        lf_nu = 100.0 * lf / (lf + hf) if (lf + hf) > 0 else float("nan")
+        hf_nu = 100.0 * hf / (lf + hf) if (lf + hf) > 0 else float("nan")
+    else:
+        vlf = lf = hf = lf_hf = total = lf_nu = hf_nu = float("nan")
+
+    summary = pd.DataFrame([{
+        "n_beats": int(len(ibi_ms) + 1),
+        "mean_hr_bpm": mean_hr,
+        "mean_ibi_ms": mean_ibi,
+        "sdnn_ms": sdnn,
+        "rmssd_ms": rmssd,
+        "pnn50_pct": pnn50,
+        "vlf_ms2": vlf,
+        "lf_ms2": lf,
+        "hf_ms2": hf,
+        "total_power_ms2": total,
+        "lf_hf_ratio": lf_hf,
+        "lf_nu": lf_nu,
+        "hf_nu": hf_nu,
+    }])
+    ibis_df = pd.DataFrame({"beat": np.arange(1, len(ibi_ms) + 1), "ibi_ms": ibi_ms})
+    return summary, ibis_df
+
+
+def motion_stats(accgyro_features: pd.DataFrame, accgyro_raw: pd.DataFrame) -> pd.DataFrame:
+    if accgyro_raw.empty:
+        return pd.DataFrame()
+    raw_cols = [c for c in ("ACC_X", "ACC_Y", "ACC_Z", "GYRO_X", "GYRO_Y", "GYRO_Z") if c in accgyro_raw.columns]
+    raw = accgyro_raw[raw_cols].to_numpy()
+    acc_xyz = raw[:, :3]
+    gyro_xyz = raw[:, 3:]
+    summary = {
+        "duration_s": float(accgyro_raw["time"].iloc[-1] - accgyro_raw["time"].iloc[0]) if "time" in accgyro_raw.columns else float("nan"),
+        "acc_mag_mean_g": float(np.linalg.norm(acc_xyz, axis=1).mean()),
+        "acc_mag_std_g":  float(np.linalg.norm(acc_xyz, axis=1).std()),
+        "gyro_mag_mean_dps": float(np.linalg.norm(gyro_xyz, axis=1).mean()),
+        "gyro_mag_std_dps":  float(np.linalg.norm(gyro_xyz, axis=1).std()),
+    }
+    if not accgyro_features.empty:
+        summary["pitch_mean_deg"] = float(accgyro_features["ACC_PITCH"].mean())
+        summary["roll_mean_deg"]  = float(accgyro_features["ACC_ROLL"].mean())
+    return pd.DataFrame([summary])
+
+
+def compute_features(pre: Preprocessed) -> Features:
+    sr = pre.sample_rates
+    bp_df, psd_df = eeg_features(pre.eeg, sr=sr.get("EEG", 256.0))
+    hr_df = heart_rate_from_bvp(pre.bvp, sr=sr.get("OPTICS", 64.0))
+    hrv_df, ibis_df = hrv_from_bvp(pre.bvp, sr=sr.get("OPTICS", 64.0))
+    motion = motion_stats(pre.accgyro_features, pre.accgyro_raw)
+    return Features(
+        eeg_band_power=bp_df, eeg_psd=psd_df, heart_rate=hr_df,
+        hrv=hrv_df, ibis=ibis_df, motion=motion, sample_rates=sr,
+    )

--- a/muse_pipeline/loaders.py
+++ b/muse_pipeline/loaders.py
@@ -1,0 +1,99 @@
+"""Load an OpenMuse `record` .txt file into decoded DataFrames."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+import json
+import pandas as pd
+
+from OpenMuse.decode import decode_rawdata
+
+SIDECAR_NAME = "recording_metadata.json"
+
+
+@dataclass
+class Recording:
+    """Decoded recording grouped by modality. Times in seconds since start."""
+    eeg: pd.DataFrame
+    accgyro: pd.DataFrame
+    optics: pd.DataFrame
+    battery: pd.DataFrame
+    sample_rates: Dict[str, float] = field(default_factory=dict)
+    source: str = ""
+    firmware: Optional[str] = None       # device firmware (e.g. "3.1.23")
+    device_address: Optional[str] = None  # CoreBluetooth UUID or MAC
+    battery_start_pct: Optional[float] = None
+
+    def __getitem__(self, key: str) -> pd.DataFrame:
+        return getattr(self, key.lower())
+
+
+def _estimate_rate(df: pd.DataFrame) -> float:
+    if df.empty or "time" not in df.columns or len(df) < 2:
+        return float("nan")
+    t = df["time"].to_numpy()
+    duration = t[-1] - t[0]
+    return (len(df) - 1) / duration if duration > 0 else float("nan")
+
+
+def _normalize_time(df: pd.DataFrame, t0: float) -> pd.DataFrame:
+    if df.empty or "time" not in df.columns:
+        return df
+    df = df.copy()
+    df["time"] = df["time"] - t0
+    return df
+
+
+def _read_sidecar(path: Path) -> dict:
+    """Look for `recording_metadata.json` next to the .txt and load it if present."""
+    sidecar = path.parent / SIDECAR_NAME
+    if not sidecar.exists():
+        return {}
+    try:
+        return json.loads(sidecar.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def load_recording(path: str | Path, firmware: str | None = None) -> Recording:
+    """Decode an OpenMuse .txt recording into a Recording object.
+
+    Pulls firmware/device metadata from `recording_metadata.json` sidecar
+    when present; the `firmware` kwarg overrides the sidecar value.
+    """
+    path = Path(path)
+    with open(path) as f:
+        lines = f.read().splitlines()
+    decoded = decode_rawdata(lines)
+    side = _read_sidecar(path)
+
+    # Pick a common t0 (earliest sample across modalities) so all clocks share an origin.
+    t0_candidates = [
+        df["time"].iloc[0] for df in decoded.values()
+        if isinstance(df, pd.DataFrame) and not df.empty and "time" in df.columns
+    ]
+    t0 = min(t0_candidates) if t0_candidates else 0.0
+
+    eeg = _normalize_time(decoded.get("EEG", pd.DataFrame()), t0)
+    accgyro = _normalize_time(decoded.get("ACCGYRO", pd.DataFrame()), t0)
+    optics = _normalize_time(decoded.get("OPTICS", pd.DataFrame()), t0)
+    battery = _normalize_time(decoded.get("BATTERY", pd.DataFrame()), t0)
+
+    rates = {
+        "EEG": _estimate_rate(eeg),
+        "ACCGYRO": _estimate_rate(accgyro),
+        "OPTICS": _estimate_rate(optics),
+        "BATTERY": _estimate_rate(battery),
+    }
+
+    return Recording(
+        eeg=eeg,
+        accgyro=accgyro,
+        optics=optics,
+        battery=battery,
+        sample_rates=rates,
+        source=str(path),
+        firmware=firmware or side.get("firmware"),
+        device_address=side.get("device_address"),
+        battery_start_pct=side.get("battery_start_pct"),
+    )

--- a/muse_pipeline/preprocess.py
+++ b/muse_pipeline/preprocess.py
@@ -1,0 +1,119 @@
+"""Per-modality preprocessing. EEG is implemented here; IMU/PPG/fNIRS wrap OpenMuse."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+import numpy as np
+import pandas as pd
+from scipy import signal
+
+from OpenMuse.process import (
+    apply_butter_filter,
+    preprocess_accgyro as _om_preprocess_accgyro,
+    preprocess_ppg as _om_preprocess_ppg,
+    preprocess_fnirs as _om_preprocess_fnirs,
+)
+
+from .loaders import Recording
+
+EEG_MAIN = ("EEG_TP9", "EEG_AF7", "EEG_AF8", "EEG_TP10")
+
+
+@dataclass
+class Preprocessed:
+    eeg: pd.DataFrame                 # filtered EEG (µV), main channels only by default
+    accgyro_features: pd.DataFrame    # ACC_MAG, PITCH, ROLL, GYRO_MAG (from OpenMuse)
+    accgyro_raw: pd.DataFrame         # untouched accgyro (carries time)
+    bvp: np.ndarray                   # fused PPG / blood volume pulse
+    bvp_info: dict
+    fnirs: pd.DataFrame               # HbO/HbR/HbDiff/SQI per position (µM)
+    fnirs_info: dict
+    sample_rates: Dict[str, float] = field(default_factory=dict)
+
+
+def _filter_eeg(
+    df: pd.DataFrame,
+    sr: float,
+    l_freq: float,
+    h_freq: float,
+    notch_freq: float | None,
+    notch_q: float,
+    main_only: bool,
+) -> pd.DataFrame:
+    if df.empty:
+        return df
+    cols = list(EEG_MAIN) if main_only else [c for c in df.columns if c != "time"]
+    out = df[["time"] + cols].copy()
+    arr = out[cols].to_numpy().T  # shape (n_channels, n_samples)
+
+    # Bandpass (zero-phase) — also removes the ~700 µV DC bias.
+    nyq = 0.5 * sr
+    sos = signal.butter(4, [l_freq / nyq, h_freq / nyq], btype="band", output="sos")
+    arr = signal.sosfiltfilt(sos, arr, axis=-1)
+
+    # Notch (zero-phase IIR) for mains hum.
+    if notch_freq is not None and notch_freq < nyq:
+        b, a = signal.iirnotch(notch_freq / nyq, notch_q)
+        arr = signal.filtfilt(b, a, arr, axis=-1)
+
+    out[cols] = arr.T
+    return out
+
+
+def preprocess_eeg(
+    df: pd.DataFrame,
+    sr: float = 256.0,
+    l_freq: float = 1.0,
+    h_freq: float = 40.0,
+    notch_freq: float | None = 60.0,
+    notch_q: float = 30.0,
+    main_only: bool = True,
+) -> pd.DataFrame:
+    """Bandpass + notch zero-phase filter EEG. Returns df with same column order."""
+    return _filter_eeg(df, sr, l_freq, h_freq, notch_freq, notch_q, main_only)
+
+
+def preprocess_accgyro(
+    df: pd.DataFrame, sr: float = 52.0, lp_cutoff: float = 5.0,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Returns (features_df, raw_df_with_time). features: ACC_MAG, PITCH, ROLL, GYRO_MAG."""
+    if df.empty:
+        return pd.DataFrame(), df
+    feat = _om_preprocess_accgyro(df, sampling_rate=int(sr), lp_cutoff=lp_cutoff)
+    feat.insert(0, "time", df["time"].to_numpy())
+    return feat, df
+
+
+def preprocess_ppg(df: pd.DataFrame, sr: float = 64.0) -> Tuple[np.ndarray, dict]:
+    """Returns (bvp, info). info contains per-channel SQI and fused weights."""
+    if df.empty:
+        return np.array([]), {}
+    return _om_preprocess_ppg(df, sampling_rate=int(sr))
+
+
+def preprocess_fnirs(df: pd.DataFrame, sr: float = 64.0) -> Tuple[pd.DataFrame, dict]:
+    """Returns (hb_df, info). hb_df has *_HbO, *_HbR, *_HbDiff, *_SQI per position."""
+    if df.empty:
+        return pd.DataFrame(), {}
+    hb_df, info = _om_preprocess_fnirs(df, sampling_rate=int(sr))
+    if "time" in df.columns and not hb_df.empty:
+        hb_df = hb_df.copy()
+        hb_df.insert(0, "time", df["time"].to_numpy())
+    return hb_df, info
+
+
+def preprocess_all(rec: Recording) -> Preprocessed:
+    sr = rec.sample_rates
+    eeg = preprocess_eeg(rec.eeg, sr=sr.get("EEG", 256.0))
+    accgyro_feat, accgyro_raw = preprocess_accgyro(rec.accgyro, sr=sr.get("ACCGYRO", 52.0))
+    bvp, bvp_info = preprocess_ppg(rec.optics, sr=sr.get("OPTICS", 64.0))
+    fnirs, fnirs_info = preprocess_fnirs(rec.optics, sr=sr.get("OPTICS", 64.0))
+    return Preprocessed(
+        eeg=eeg,
+        accgyro_features=accgyro_feat,
+        accgyro_raw=accgyro_raw,
+        bvp=bvp,
+        bvp_info=bvp_info,
+        fnirs=fnirs,
+        fnirs_info=fnirs_info,
+        sample_rates=sr,
+    )

--- a/muse_pipeline/quality.py
+++ b/muse_pipeline/quality.py
@@ -1,0 +1,109 @@
+"""Per-modality quality metrics."""
+from __future__ import annotations
+from typing import Dict
+import numpy as np
+import pandas as pd
+from scipy import signal
+
+from .loaders import Recording
+from .preprocess import Preprocessed, EEG_MAIN
+
+# OpenMuse decodes EEG to a 14-bit ADC range scaled into µV (0..1450 µV).
+# Saturation = sample at either rail.
+EEG_RAIL_LO = 0.0
+EEG_RAIL_HI = 1450.0
+
+
+def eeg_quality(raw_eeg: pd.DataFrame, filt_eeg: pd.DataFrame, sr: float) -> pd.DataFrame:
+    """Per-channel EEG quality: saturation %, std, line-noise ratio, simple SQI in [0, 1]."""
+    if raw_eeg.empty or filt_eeg.empty:
+        return pd.DataFrame()
+    chans = [c for c in EEG_MAIN if c in raw_eeg.columns and c in filt_eeg.columns]
+    rows = []
+    nyq = 0.5 * sr
+    for ch in chans:
+        raw = raw_eeg[ch].to_numpy()
+        filt = filt_eeg[ch].to_numpy()
+        sat_pct = float(((raw <= EEG_RAIL_LO + 1e-6) | (raw >= EEG_RAIL_HI - 1e-6)).mean() * 100.0)
+        std_uv = float(filt.std())
+
+        # Line-noise (~60 Hz ± 1 Hz) power vs broadband 1–40 Hz power on the filtered signal.
+        if len(filt) >= int(sr * 4):
+            f, P = signal.welch(filt, fs=sr, nperseg=int(sr * 4))
+            band_mask = (f >= 1) & (f <= 40)
+            line_mask = (f >= 59) & (f <= 61)
+            band_pow = float(P[band_mask].sum())
+            line_pow = float(P[line_mask].sum())
+            line_ratio = line_pow / band_pow if band_pow > 0 else float("nan")
+        else:
+            line_ratio = float("nan")
+
+        # SQI heuristic: penalise saturation, runaway std, and dominant line noise.
+        # Healthy EEG typically std 5–80 µV after 1–40 Hz bandpass.
+        std_score = float(np.clip(1.0 - max(0.0, (std_uv - 80.0) / 200.0), 0.0, 1.0)) if std_uv > 0 else 0.0
+        if std_uv < 1.0:
+            std_score = 0.0  # too flat = disconnected
+        sat_score = float(np.clip(1.0 - sat_pct / 5.0, 0.0, 1.0))   # >5% saturated -> 0
+        line_score = float(np.clip(1.0 - (line_ratio if line_ratio == line_ratio else 0.0) * 5.0, 0.0, 1.0))
+        sqi = float(np.clip(0.45 * sat_score + 0.35 * std_score + 0.20 * line_score, 0.0, 1.0))
+
+        rows.append({
+            "channel": ch,
+            "saturation_pct": sat_pct,
+            "std_uV": std_uv,
+            "line_noise_ratio_60Hz": line_ratio,
+            "sqi": sqi,
+        })
+    return pd.DataFrame(rows)
+
+
+def fnirs_quality(fnirs: pd.DataFrame) -> pd.DataFrame:
+    """Mean SQI per fNIRS position (from OpenMuse's anticorrelation SQI)."""
+    if fnirs.empty:
+        return pd.DataFrame()
+    sqi_cols = [c for c in fnirs.columns if c.endswith("_SQI")]
+    rows = []
+    for c in sqi_cols:
+        pos = c.replace("_SQI", "")
+        v = fnirs[c].to_numpy()
+        v = v[np.isfinite(v)]
+        rows.append({
+            "position": pos,
+            "sqi_mean": float(v.mean()) if v.size else float("nan"),
+            "sqi_min": float(v.min())  if v.size else float("nan"),
+            "good_pct": float((v > 0.3).mean() * 100.0) if v.size else float("nan"),
+        })
+    return pd.DataFrame(rows)
+
+
+def battery_summary(battery: pd.DataFrame) -> pd.DataFrame:
+    if battery.empty:
+        return pd.DataFrame()
+    col = "battery_percent" if "battery_percent" in battery.columns else battery.columns[-1]
+    return pd.DataFrame([{
+        "samples": int(len(battery)),
+        "start_pct": float(battery[col].iloc[0]),
+        "end_pct": float(battery[col].iloc[-1]),
+        "drop_pct": float(battery[col].iloc[0] - battery[col].iloc[-1]),
+    }])
+
+
+def recording_summary(rec: Recording) -> pd.DataFrame:
+    rows = []
+    for name, df in [("EEG", rec.eeg), ("ACCGYRO", rec.accgyro), ("OPTICS", rec.optics), ("BATTERY", rec.battery)]:
+        if df.empty or "time" not in df.columns:
+            rows.append({"modality": name, "samples": int(len(df)), "duration_s": 0.0, "rate_hz": float("nan")})
+            continue
+        dur = float(df["time"].iloc[-1] - df["time"].iloc[0])
+        rate = (len(df) - 1) / dur if dur > 0 else float("nan")
+        rows.append({"modality": name, "samples": int(len(df)), "duration_s": dur, "rate_hz": float(rate)})
+    return pd.DataFrame(rows)
+
+
+def compute_quality(rec: Recording, pre: Preprocessed) -> Dict[str, pd.DataFrame]:
+    return {
+        "summary": recording_summary(rec),
+        "eeg": eeg_quality(rec.eeg, pre.eeg, sr=rec.sample_rates.get("EEG", 256.0)),
+        "fnirs": fnirs_quality(pre.fnirs),
+        "battery": battery_summary(rec.battery),
+    }

--- a/muse_pipeline/runner.py
+++ b/muse_pipeline/runner.py
@@ -1,0 +1,41 @@
+"""Top-level pipeline runner."""
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict
+import time
+
+from .loaders import load_recording
+from .preprocess import preprocess_all
+from .features import compute_features
+from .quality import compute_quality
+from .export import export_all
+
+
+def run_pipeline(input_path: str | Path, outdir: str | Path, firmware: str | None = None) -> Dict[str, Path]:
+    """Run the full offline pipeline on an OpenMuse `.txt` recording.
+
+    firmware: optional override; otherwise read from `recording_metadata.json`
+    sidecar next to the input file (if present).
+    """
+    input_path = Path(input_path)
+    outdir = Path(outdir)
+    t0 = time.time()
+    print(f"[1/5] decoding   {input_path}")
+    rec = load_recording(input_path, firmware=firmware)
+    if rec.firmware:
+        print(f"      firmware: {rec.firmware}  device: {rec.device_address or '(unknown)'}")
+    print(f"      sample rates (Hz): {rec.sample_rates}")
+
+    print("[2/5] preprocess")
+    pre = preprocess_all(rec)
+
+    print("[3/5] features")
+    feats = compute_features(pre)
+
+    print("[4/5] quality")
+    qc = compute_quality(rec, pre)
+
+    print(f"[5/5] export -> {outdir}")
+    written = export_all(rec, pre, feats, qc, outdir)
+    print(f"done in {time.time() - t0:.1f}s — {len(written)} artifacts")
+    return written

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "muse_pipeline"
+version = "0.1.0"
+description = "Offline + cued-protocol analysis pipeline for Muse S Athena via OpenMuse"
+requires-python = ">=3.12"
+dependencies = [
+    "OpenMuse",
+    "PySide6",
+    "mne>=1.5",
+    "mne-lsl",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "scipy",
+]
+
+[tool.setuptools.packages.find]
+include = ["muse_pipeline*", "experiments*"]


### PR DESCRIPTION
Adds `muse_pipeline/` — an installable Python package that decodes OpenMuse `record` .txt files into per-modality DataFrames (EEG / ACCGYRO / OPTICS / BATTERY), runs standard preprocessing, computes EEG band power + HR + HRV + motion features, scores per-channel quality, and exports the results as Parquet/CSV + MNE FIF + a one-page QC PDF.

Adds `experiments/eyes_open_closed.py` — a cued recording protocol that spawns `OpenMuse record` as a subprocess, drives on-screen cues, captures device firmware/battery from OpenMuse's stdout, and writes a synchronised events.csv + recording_metadata.json sidecar. The companion `experiments/analyze_eoec.py` runs the pipeline and produces a per-condition Welch t-test report.

fNIRS outputs (HbO/HbR/HbDiff) are flagged as EXPERIMENTAL in the metadata and on the QC PDF, referencing OpenMuse issue #23 where the maintainer notes the optics-to-fNIRS computation is still unclear and unvalidated and that a recent firmware update changed optics behavior. EEG, IMU, BVP/HR/HRV outputs are not flagged.

Adds `contributions/openmuse_pr/` — a draft of three upstream-ready functions (preprocess_eeg, eeg_band_power, hrv_from_bvp) matching OpenMuse's existing style + an issue text proposing them as a small PR, intentionally scoped away from the fNIRS area.

Updates `.gitignore` for the Python side (egg-info, out/, runs/, .DS_Store, athena_test.txt). Does not modify any of the original BlueMuse Windows project files.